### PR TITLE
Fixed: ServiceInspectWithRaw missing parameter

### DIFF
--- a/extractors/swarm.go
+++ b/extractors/swarm.go
@@ -29,7 +29,11 @@ func SwarmExtractor(info *types.ContainerJSON) (*policy.PURuntime, error) {
 
 		serviceID := info.Config.Labels["com.docker.swarm.service.id"]
 
-		service, _, err := cli.ServiceInspectWithRaw(context.Background(), serviceID)
+		opts := types.ServiceInspectOptions{
+			InsertDefaults: true,
+		}
+
+		service, _, err := cli.ServiceInspectWithRaw(context.Background(), serviceID, opts)
 		if err != nil {
 			return nil, fmt.Errorf("Failed get swarm labels: %s", err)
 		}


### PR DESCRIPTION
Currently, our `extractor/swarm.go` is calling dockerClient's `ServiceInspectWithRaw` method without `opts` parameter.

According to the latest documentation, here is the prototype of this method:
```
func (cli *Client) ServiceInspectWithRaw(ctx context.Context, serviceID string, opts types.ServiceInspectOptions) (swarm.Service, []byte, error)
```

This PR forces the `opts` parameter.
