### PR TITLE
New: log level with Trace (optional)

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -4,7 +4,7 @@ import:
 
   ## Aporeto
 - package: github.com/aporeto-inc/trireme
-  version: 1.0.x
+  version: fdfebd9a952c2187a8ba32cfd699a2aa95831376
 
   ## 3rd Party
 - package: github.com/docker/docker

--- a/glide.yaml
+++ b/glide.yaml
@@ -4,7 +4,7 @@ import:
 
   ## Aporeto
 - package: github.com/aporeto-inc/trireme
-  version: fdfebd9a952c2187a8ba32cfd699a2aa95831376
+  version: 1.0.x
 
   ## 3rd Party
 - package: github.com/docker/docker

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"syscall"
 
 	"github.com/aporeto-inc/trireme-example/triremecli"
+	"github.com/aporeto-inc/trireme/log"
 	docopt "github.com/docopt/docopt-go"
 	"go.uber.org/zap"
 )
@@ -18,7 +19,10 @@ func Configure(level string) zap.Config {
 
 	// Set the logger
 	switch level {
-	case "trace", "debug":
+	case "trace":
+		config.Level = zap.NewAtomicLevelAt(zap.DebugLevel)
+		log.Trace = true
+	case "debug":
 		config.Level = zap.NewAtomicLevelAt(zap.DebugLevel)
 	case "info":
 		config.Level = zap.NewAtomicLevelAt(zap.InfoLevel)


### PR DESCRIPTION
This new feature uses the capability of Trireme to use a Trace global log level.
If the user sets trireme-example to be used with Trace, then it will result in having zap in debug mode and trace the headers of all the packets.

Debug mode means the header of all the packets will not be printed.