### PR TITLE
Add JSON policy to trireme-example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,15 @@
 # Trireme Example
 
 This repo provides a simple implementation of network isolation using the
-Trireme library in a standalone mode without any control plane. It implements
-the trireme policy interface with a simple static policy: Two containers can
-talk to each other if they have at least one label that matches.
+Trireme library in a standalone mode without any control plane. By default,
+it implements the trireme policy interface with a simple static policy:
 
+* Default Policy: Two containers can talk to each other if they have at least one label that matches.
+
+The simple example also provides an illustration of how to integrate Trireme
+with a more complex policy system. We demonstrate that by allowing Trireme to
+load a policy configuration through a JSON file. An example of such policy
+can be found the policy.json file.
 
 # Trying it quickly
 
@@ -24,7 +29,9 @@ aporeto/trireme-example daemon --hybrid
 
 This script will load a docker container in privileged and host mode that will run this example. Trireme
 will be installed with remote enforcers and it is compatible with any networking technique that is
-possible in the host machine.
+possible in the host machine, including IPVLAN/MacVLAN. The network isolation is even performed
+when you are starting containers with the --net=host parameter in Docker (i.e. when containers
+are started in the host namespace).
 
 You can start a docker container with a specific label (in this case **app=web**)
 
@@ -48,14 +55,62 @@ curl http://<nginx-IP>
 ```
 fails.
 
-## Trying it with Docker Swarm
+## Supporting host networking
 
-Trireme also has support for Docker Swarm including any overlay networks. This functionality is
-based on a remote execution capability where Trireme will intercept traffic before any
-of the libnetwork plugins even see the packets. This allows Trireme to support any of the
-network plugins.
+Trireme isolation is also possible for containers that start with host networking. There are
+several use cases where one might choose to do that, if they want to associate a static IP
+address with a container or a similar function. For example, the API Router in Redhat OpenShift
+uses the host network. When one uses the host network there is a big problem that the isolation
+of network namespaces is lost. Trireme brings back some of this isolation and treats every
+container differently, although they are possibly mapped in the same network namespace.
 
-In order to try it, compile the example:
+Let us assume that you Trireme running as in the previous example. You can start a docker
+container with a specific label and attached to the host namespace:
+
+```bash
+docker run -l app=web --net=host -d nginx
+```
+
+In this case the nginx server is attached to the host network and can be accessed directly from
+the host. If you try
+
+```bash
+curl http://127.0.0.1
+```
+
+The curl command will fail. Similarly, it will fail if you target it to the host bridge. The reason
+is that Trireme still controls access to the container. However, if you try something like that:
+
+```bash
+docker run -l app=web -it centos
+curl http://172.17.0.1
+```
+
+The curl command will succeed.
+
+# Building Trireme Example
+
+If you want to build and try Trireme example with more advanced options and Linux Services
+you need to follow these instructions. Please make sure that Go 1.8 is installed in
+your machine. Trireme has some dependencies. libnetfilter-queue and conntrack utilities
+must be also installed and your OS must support iptables 1.6 or greater.
+
+For example in an Ubuntu distribution:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y libnetfilter-queue1 iptables
+iptables -version
+```
+
+for Centos:
+```bash
+sudo yum update
+sudo yum install libnetfilter_queue1 iptables
+iptables -version
+```
+
+In order to build Trireme, simply do:
 
 ```bash
 make build
@@ -67,12 +122,58 @@ path try
 make install
 ```
 
-By default this installs trireme in /usr/local/bin. If you want to change the destination please
+By default this installs trireme-example in /usr/local/bin. If you want to change the destination please
 edit the Makefile and the BIN_PATH variable.
+
+## Trying Trireme with any Linux process
+
+Trireme supports any Linux process by extracting metadata from the Linux environment as
+well as attributes supplied by the users. Trireme uses network cgroups (net_cls) capabilities
+to isolate traffic from each process.
+
+First, compile the Trireme example as in the previous section. Start Trireme in hybrid mode
+supporting both Linux processes and containers at the same time. Optionally, you can
+specify the networks that you want Trireme to apply (by default it will apply to all networks).
+In the example below we apply Trireme only on the localhost traffic.
+
+```bash
+sudo trireme-example daemon --hybrid
+```
+
+Start an nginx server as a Linux process (make sure you have the nginx binary available at `/usr/sbin/nginx`, or adapt accordingly) :
+
+```bash
+sudo trireme-example run --ports=80 --label=app=web /usr/sbin/nginx  -- '-g daemon off;'
+```
+
+The above command starts the nginx server, listening on port 80. If you try to access this nginx
+server with a curl command communication will fail. Note, that you need to supply to Trireme
+the ports that your process will be listening. Now start with a curl command and associated
+metadata:
+
+```bash
+trireme-example run --label=app=web /usr/bin/curl -- -p http://172.17.0.1
+```
+This command should succeed.
+
+You can also start a docker container with the same metadata
+```bash
+docker run -l app=web -it centos
+```
+
+And you can access the nginx server at the host. However if you start the container
+with different labels you will not able able to access the nginx container.
+
+## Trying it with Docker Swarm
+
+Trireme also has support for Docker Swarm including any overlay networks. This functionality is
+based on a remote execution capability where Trireme will intercept traffic before any
+of the libnetwork plugins even see the packets. This allows Trireme to support any of the
+network plugins.
 
 
 ```bash
-sudo ./trireme --remote --swarm
+sudo trireme-example --remote --swarm
 ```
 
 This activates Trireme with the remove enforcer capabilities and a Swarm specific
@@ -92,50 +193,119 @@ docker service create --network mynet --name client -l app=web tester
 Assuming that your tester container includes some curl capability, you can immediately
 see that the tester can access the nginx server.
 
-## Trying Trireme with any Linux process
+## Custom policy
 
-Trireme supports any Linux process by extracting metadata from the Linux environment as
-well as attributes supplied by the users. Trireme uses network cgroups (net_cls) capabilities
-to isolate traffic from each process.
+The default operation of the example assumes that the policy will allow containers or
+processes to exchange data if they have the same labels. However, the example offers
+an alternative method where you can define a custom policy through a JSON configuration
+file. Let's see an example of this policy:
 
-First, compile the Trireme example as in the previous section. Start Trireme in hybrid mode
-supporting both Linux processes and containers at the same time. You must specify the networks
-that you want Trireme to apply (by default it uses the docker bridge only). In the example
-below we apply Trireme only on the localhost traffic.
+```json
+{
+    "Web": {
+        "ApplicationACLs": [
+            {
+                "Address": "192.30.253.0/24",
+                "Policy": {
+                    "Action": 1,
+                    "PolicyID": "1",
+                    "ServiceID": ""
+                },
+                "Port": "80",
+                "Protocol": "TCP"
+            },
+            {
+                "Address": "0.0.0.0/0",
+                "Policy": {
+                    "Action": 1,
+                    "PolicyID": "4",
+                    "ServiceID": ""
+                },
+                "Port": "53",
+                "Protocol": "udp"
+            }
+        ],
+        "NetworkACLs": [
+            {
+                "Address": "0.0.0.0/0",
+                "Policy": {
+                    "Action": 1,
+                    "PolicyID": "7",
+                    "ServiceID": ""
+                },
+                "Port": "",
+                "Protocol": "icmp"
+            }
+        ],
+        "TagSelectors": [
+            {
+                "Clause": [
+                    {
+                        "Key": "@usr:app",
+                        "Operator": "=",
+                        "Value": [
+                            "web"
+                        ]
+                    }
+                ],
+                "Policy": {
+                    "Action": 1,
+                    "PolicyID": "8",
+                    "ServiceID": ""
+                }
+            },
+            {
+                "Clause": [
+                    {
+                        "Key": "@usr:env",
+                        "Operator": "=",
+                        "Value": [
+                            "dev"
+                        ]
+                    }
+                ],
+                "Policy": {
+                    "Action": 1,
+                    "PolicyID": "8",
+                    "ServiceID": ""
+                }
+            }
+        ]
+    },
+  }
+  ```
 
-```bash
-sudo ./trireme daemon --hybrid --target-networks=127.0.0.1
-```
+In the above example, the name of the policy is "Web" and there are three main
+sections:
 
-Start an nginx server as a Linux process (make sure you have the nginx binary available at `/usr/sbin/nginx`, or adapt accordingly) :
+1. `ApplicationACLs` describe what traffic the container can send to nodes that
+are not protected by a Trireme process. The Trireme library defaults to ACLs if
+the other nodes are not Trireme based. This is done by auto-detecting whether
+the receiver of traffic is Trireme enabled and it responds with the proper
+authorization headers. Note also, that by using ApplicationACLs we can allow
+DNS traffic or other similar services. By default Trireme will block all other
+traffic from the container. 
+2. `NetworkACLs` describes what traffic should be accepted if the other side
+does not present any network authorization headers. In general this should be
+avoided, but there are specific use cases that someone might want to achieve that.
+3. `TagSelectors` describe the list of authorization policies that have be to
+applied to the attributes of the identity. In the above example, traffic from
+containers that have been identified as "@usr:app=web" or "@usr:env=dev" will
+be accepted. Note here the use of the "@usr" prefix. This indicates that this is
+a tag supplied by the user and can be trusted as long as the user can be trusted.
+On the other hand a "@sys" prefixed tag indicates a tag that the system has
+discovered and its generally trusted.
 
-```bash
-sudo ./trireme run --ports=80 --label=app=web /usr/sbin/nginx  -- '-g daemon off;'
-```
-
-The above command starts the nginx server, listening on port 80. If you try to access this nginx
-server with a curl command communication will fail. Now start with a curl command and associated
-metadata:
-
-```bash
-./trireme run --label=app=web /usr/bin/curl -- -p http://172.17.0.1
-```
-This command should succeed.
-
-You can also start a docker container with the same metadata
-```bash
-docker run -l app=web -it centos
-```
-
-And you can access the nginx server at the host. However if you start the container
-with different labels you will not able able to access the nginx container.
+In order to load the policy to Trireme-Example you can need to define the file
+with the --policy parameter.
 
 # Understanding the simple example.
 
-Trireme can be launched with a PresharedKey for authentication (the default mode of this example), or can use a Public Key Infrastructure based on certificates
-In both those cases, the constructors package provides helpers that will instantiate Trireme with mostly default parameters. You can
-launch Trireme with PKI by simply running with the --usePKI option after you generate the right certificates. An example of
-self-signed certificates is provided in the certs directory.
+Trireme can be launched with a PresharedKey for authentication (the default mode of this example),
+or can use a Public Key Infrastructure based on certificates. In both those cases, the constructors
+package provides helpers that will instantiate Trireme with mostly default parameters. You can
+launch Trireme with PKI by simply running with the --usePKI option after you generate the right
+certificates. An example of self-signed certificates is provided in the certs directory.
 
 ## Trireme with PSK.
 
@@ -175,28 +345,3 @@ certificates.
 ```bash
 ./create_certs.sh
 ```
-
-# Building
-
-If you want to build the binary without a docker container, you must have 'libnetfilter-queue' installed in your system. For example in an Ubuntu distribution:
-
-```bash
-sudo apt-get update
-sudo apt-get install -y libnetfilter-queue-dev iptables
-```
-
-for Centos:
-```bash
-sudo yum update
-sudo yum install libnetfilter_queue-devel
-```
-
-Building is just:
-
-```bash
-# Install the required dependencies
-glide install
-# Build
-make build
-```
-

--- a/README.md
+++ b/README.md
@@ -55,39 +55,6 @@ curl http://<nginx-IP>
 ```
 fails.
 
-## Supporting host networking
-
-Trireme isolation is also possible for containers that start with host networking. There are
-several use cases where one might choose to do that, if they want to associate a static IP
-address with a container or a similar function. For example, the API Router in Redhat OpenShift
-uses the host network. When one uses the host network there is a big problem that the isolation
-of network namespaces is lost. Trireme brings back some of this isolation and treats every
-container differently, although they are possibly mapped in the same network namespace.
-
-Let us assume that you Trireme running as in the previous example. You can start a docker
-container with a specific label and attached to the host namespace:
-
-```bash
-docker run -l app=web --net=host -d nginx
-```
-
-In this case the nginx server is attached to the host network and can be accessed directly from
-the host. If you try
-
-```bash
-curl http://127.0.0.1
-```
-
-The curl command will fail. Similarly, it will fail if you target it to the host bridge. The reason
-is that Trireme still controls access to the container. However, if you try something like that:
-
-```bash
-docker run -l app=web -it centos
-curl http://172.17.0.1
-```
-
-The curl command will succeed.
-
 # Building Trireme Example
 
 If you want to build and try Trireme example with more advanced options and Linux Services
@@ -163,6 +130,39 @@ docker run -l app=web -it centos
 
 And you can access the nginx server at the host. However if you start the container
 with different labels you will not able able to access the nginx container.
+
+## Supporting host networking
+
+Trireme isolation is also possible for containers that start with host networking. There are
+several use cases where one might choose to do that, if they want to associate a static IP
+address with a container or a similar function. For example, the API Router in Redhat OpenShift
+uses the host network. When one uses the host network there is a big problem that the isolation
+of network namespaces is lost. Trireme brings back some of this isolation and treats every
+container differently, although they are possibly mapped in the same network namespace.
+
+Let us assume that you Trireme running as in the previous example. You can start a docker
+container with a specific label and attached to the host namespace:
+
+```bash
+docker run -l app=web --net=host -d nginx
+```
+
+In this case the nginx server is attached to the host network and can be accessed directly from
+the host. If you try
+
+```bash
+curl http://127.0.0.1
+```
+
+The curl command will fail. Similarly, it will fail if you target it to the host bridge. The reason
+is that Trireme still controls access to the container. However, if you try something like that:
+
+```bash
+docker run -l app=web -it centos
+curl http://172.17.0.1
+```
+
+The curl command will succeed.
 
 ## Trying it with Docker Swarm
 
@@ -284,7 +284,7 @@ the other nodes are not Trireme based. This is done by auto-detecting whether
 the receiver of traffic is Trireme enabled and it responds with the proper
 authorization headers. Note also, that by using ApplicationACLs we can allow
 DNS traffic or other similar services. By default Trireme will block all other
-traffic from the container. 
+traffic from the container.
 2. `NetworkACLs` describes what traffic should be accepted if the other side
 does not present any network authorization headers. In general this should be
 avoided, but there are specific use cases that someone might want to achieve that.

--- a/README.md
+++ b/README.md
@@ -59,21 +59,21 @@ fails.
 
 If you want to build and try Trireme example with more advanced options and Linux Services
 you need to follow these instructions. Please make sure that Go 1.8 is installed in
-your machine. Trireme has some dependencies. libnetfilter-queue and conntrack utilities
+your machine. Trireme has some dependencies. libnetfilter-queue and ipset utilities
 must be also installed and your OS must support iptables 1.6 or greater.
 
 For example in an Ubuntu distribution:
 
 ```bash
 sudo apt-get update
-sudo apt-get install -y libnetfilter-queue1 iptables
+sudo apt-get install -y libnetfilter-queue1 iptables ipset
 iptables -version
 ```
 
 for Centos:
 ```bash
 sudo yum update
-sudo yum install libnetfilter_queue1 iptables
+sudo yum install libnetfilter_queue1 iptables ipset 
 iptables -version
 ```
 

--- a/constructors/constructors.go
+++ b/constructors/constructors.go
@@ -25,7 +25,7 @@ var (
 )
 
 // TriremeWithPKI is a helper method to created a PKI implementation of Trireme
-func TriremeWithPKI(keyFile, certFile, caCertFile string, networks []string, extractor *dockermonitor.DockerMetadataExtractor, remoteEnforcer bool, killContainerError bool) (trireme.Trireme, monitor.Monitor) {
+func TriremeWithPKI(keyFile, certFile, caCertFile string, networks []string, extractor *dockermonitor.DockerMetadataExtractor, remoteEnforcer bool, killContainerError bool, policyFile string) (trireme.Trireme, monitor.Monitor) {
 
 	// Load client cert
 	certPEM, err := ioutil.ReadFile(certFile)
@@ -50,7 +50,7 @@ func TriremeWithPKI(keyFile, certFile, caCertFile string, networks []string, ext
 		zap.L().Fatal(err.Error())
 	}
 
-	policyEngine := policyexample.NewCustomPolicyResolver(networks)
+	policyEngine := policyexample.NewCustomPolicyResolver(networks, policyFile)
 
 	t, m, p := configurator.NewPKITriremeWithDockerMonitor("Server1", policyEngine, ExternalProcessor, nil, false, keyPEM, certPEM, caCertPEM, *extractor, remoteEnforcer, killContainerError)
 
@@ -62,27 +62,27 @@ func TriremeWithPKI(keyFile, certFile, caCertFile string, networks []string, ext
 }
 
 //TriremeWithPSK is a helper method to created a PSK implementation of Trireme
-func TriremeWithPSK(networks []string, extractor *dockermonitor.DockerMetadataExtractor, remoteEnforcer bool, killContainerError bool) (trireme.Trireme, monitor.Monitor) {
+func TriremeWithPSK(networks []string, extractor *dockermonitor.DockerMetadataExtractor, remoteEnforcer bool, killContainerError bool, policyFile string) (trireme.Trireme, monitor.Monitor) {
 
-	policyEngine := policyexample.NewCustomPolicyResolver(networks)
+	policyEngine := policyexample.NewCustomPolicyResolver(networks, policyFile)
 
 	// Use this if you want a pre-shared key implementation
 	return configurator.NewPSKTriremeWithDockerMonitor("Server1", policyEngine, ExternalProcessor, nil, false, []byte("THIS IS A BAD PASSWORD"), *extractor, remoteEnforcer, killContainerError)
 }
 
 //TriremeCNIWithPSK is a helper method to created a PSK implementation of Trireme
-func TriremeCNIWithPSK(networks []string, remoteEnforcer bool, killContainerError bool) (trireme.Trireme, monitor.Monitor) {
+func TriremeCNIWithPSK(networks []string, remoteEnforcer bool, killContainerError bool, policyFile string) (trireme.Trireme, monitor.Monitor) {
 
-	policyEngine := policyexample.NewCustomPolicyResolver(networks)
+	policyEngine := policyexample.NewCustomPolicyResolver(networks, policyFile)
 
 	// Use this if you want a pre-shared key implementation
 	return configurator.NewPSKTriremeWithCNIMonitor("Server1", policyEngine, ExternalProcessor, nil, []byte("THIS IS A BAD PASSWORD"), cnimonitor.DockerCNIMetadataExtractor, true)
 }
 
 //HybridTriremeWithPSK is a helper method to created a PSK implementation of Trireme
-func HybridTriremeWithPSK(networks []string, extractor *dockermonitor.DockerMetadataExtractor, killContainerError bool) (trireme.Trireme, monitor.Monitor, monitor.Monitor) {
+func HybridTriremeWithPSK(networks []string, extractor *dockermonitor.DockerMetadataExtractor, killContainerError bool, policyFile string) (trireme.Trireme, monitor.Monitor, monitor.Monitor) {
 
-	policyEngine := policyexample.NewCustomPolicyResolver(networks)
+	policyEngine := policyexample.NewCustomPolicyResolver(networks, policyFile)
 
 	pass := []byte("THIS IS A BAD PASSWORD")
 	// Use this if you want a pre-shared key implementation
@@ -90,7 +90,7 @@ func HybridTriremeWithPSK(networks []string, extractor *dockermonitor.DockerMeta
 }
 
 // HybridTriremeWithCompactPKI is a helper method to created a PKI implementation of Trireme
-func HybridTriremeWithCompactPKI(keyFile, certFile, caCertFile, caKeyFile string, networks []string, extractor *dockermonitor.DockerMetadataExtractor, remoteEnforcer bool, killContainerError bool) (trireme.Trireme, monitor.Monitor, monitor.Monitor) {
+func HybridTriremeWithCompactPKI(keyFile, certFile, caCertFile, caKeyFile string, networks []string, extractor *dockermonitor.DockerMetadataExtractor, remoteEnforcer bool, killContainerError bool, policyFile string) (trireme.Trireme, monitor.Monitor, monitor.Monitor) {
 
 	// Load client cert
 	certPEM, err := ioutil.ReadFile(certFile)
@@ -125,14 +125,14 @@ func HybridTriremeWithCompactPKI(keyFile, certFile, caCertFile, caKeyFile string
 		zap.L().Fatal(err.Error())
 	}
 
-	policyEngine := policyexample.NewCustomPolicyResolver(networks)
+	policyEngine := policyexample.NewCustomPolicyResolver(networks, policyFile)
 
 	return configurator.NewHybridCompactPKIWithDocker("Server1", networks, policyEngine, ExternalProcessor, nil, false, keyPEM, certPEM, caCertPEM, token, *extractor, remoteEnforcer, killContainerError)
 
 }
 
 // TriremeWithCompactPKI is a helper method to created a PKI implementation of Trireme
-func TriremeWithCompactPKI(keyFile, certFile, caCertFile, caKeyFile string, networks []string, extractor *dockermonitor.DockerMetadataExtractor, remoteEnforcer bool, killContainerError bool) (trireme.Trireme, monitor.Monitor) {
+func TriremeWithCompactPKI(keyFile, certFile, caCertFile, caKeyFile string, networks []string, extractor *dockermonitor.DockerMetadataExtractor, remoteEnforcer bool, killContainerError bool, policyFile string) (trireme.Trireme, monitor.Monitor) {
 
 	// Load client cert
 	certPEM, err := ioutil.ReadFile(certFile)
@@ -167,7 +167,7 @@ func TriremeWithCompactPKI(keyFile, certFile, caCertFile, caKeyFile string, netw
 		zap.L().Fatal(err.Error())
 	}
 
-	policyEngine := policyexample.NewCustomPolicyResolver(networks)
+	policyEngine := policyexample.NewCustomPolicyResolver(networks, policyFile)
 
 	return configurator.NewCompactPKIWithDocker("Server1", networks, policyEngine, ExternalProcessor, nil, false, keyPEM, certPEM, caCertPEM, token, *extractor, remoteEnforcer, killContainerError)
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,7 +5,8 @@ RUN mkdir -p /opt/trireme
 RUN apt-get update && apt-get install -y \
     libnetfilter-queue1 \
     iptables \
-    iproute2
+    iproute2 \
+    ipset
 
 ADD trireme-example /opt/trireme/trireme-example
 

--- a/extractors/swarm.go
+++ b/extractors/swarm.go
@@ -29,7 +29,7 @@ func SwarmExtractor(info *types.ContainerJSON) (*policy.PURuntime, error) {
 
 		serviceID := info.Config.Labels["com.docker.swarm.service.id"]
 
-		service, _, err := cli.ServiceInspectWithRaw(context.Background(), serviceID, types.ServiceInspectOptions{})
+		service, _, err := cli.ServiceInspectWithRaw(context.Background(), serviceID)
 		if err != nil {
 			return nil, fmt.Errorf("Failed get swarm labels: %s", err)
 		}

--- a/extractors/swarm.go
+++ b/extractors/swarm.go
@@ -29,7 +29,7 @@ func SwarmExtractor(info *types.ContainerJSON) (*policy.PURuntime, error) {
 
 		serviceID := info.Config.Labels["com.docker.swarm.service.id"]
 
-		service, _, err := cli.ServiceInspectWithRaw(context.Background(), serviceID)
+		service, _, err := cli.ServiceInspectWithRaw(context.Background(), serviceID, types.ServiceInspectOptions{})
 		if err != nil {
 			return nil, fmt.Errorf("Failed get swarm labels: %s", err)
 		}

--- a/main.go
+++ b/main.go
@@ -70,26 +70,27 @@ func main() {
 	usage := `Command for launching programs with Trireme policy.
 
   Usage:
-    trireme -h | --help
-    trireme --version
-    trireme run
+    trireme-example -h | --help
+    trireme-example --version
+    trireme-example run
         [--service-name=<sname>]
         [[--label=<keyvalue>]...]
         [--ports=<ports>]
         <command> [--] [<params>...]
-    trireme daemon
+    trireme-example daemon
         [--target-networks=<networks>...]
+	[--policy=<policyFile>]
         [--usePKI]
         [--hybrid|--remote|--local|--cni]
         [--swarm|--extractor <metadatafile>]
         [--keyFile=<keyFile>]
         [--certFile=<certFile>]
         [--caCertFile=<caCertFile>]
-				[--caKeyFile=<caKeyFile>]
+	[--caKeyFile=<caKeyFile>]
         [--log-level=<log-level>]
-    trireme enforce
+    trireme-example enforce
         [--log-level=<log-level>]
-    trireme <cgroup>
+    trireme-example <cgroup>
 
   Options:
     -h --help                              Show this help message and exit.
@@ -101,12 +102,13 @@ func main() {
     --keyFile=<keyFile>                    Key file [default: certs/cert-key.pem].
     --caCertFile=<caCertFile>              CA certificate [default: certs/ca.pem].
     --caKeyFile=<caKeyFile>                CA key [default: certs/ca-key.pem].
-    --hybrid                               Hybrid mode of deployment [default: false]
-    --remote                               Remote mode of deployment [default: false]
-    --cni                                  Remote mode of deployment [default: false]
-    --local                                Local mode of deployment [default: true]
-    --swarm                                Deploy Doccker Swarm metadata extractor [default: false]
-    --extractor                            External metadata extractor [default: ]
+    --hybrid                               Hybrid mode of deployment [default: false].
+    --remote                               Remote mode of deployment [default: false].
+    --cni                                  Remote mode of deployment [default: false].
+    --local                                Local mode of deployment [default: true].
+    --swarm                                Deploy Doccker Swarm metadata extractor [default: false].
+    --extractor                            External metadata extractor [default: ].
+    --policy=<policyFile>                  Policy file [default: policy.json].
     --target-networks=<networks>...        The target networks that Trireme should apply authentication [default: ]
     <cgroup>                               cgroup of process that are terminated.
 

--- a/policy.json
+++ b/policy.json
@@ -1,0 +1,126 @@
+{
+    "Web": {
+        "ApplicationACLs": [
+            {
+                "Address": "192.30.253.0/24",
+                "Policy": {
+                    "Action": 1,
+                    "PolicyID": "1",
+                    "ServiceID": ""
+                },
+                "Port": "80",
+                "Protocol": "TCP"
+            },
+            {
+                "Address": "192.30.253.0/24",
+                "Policy": {
+                    "Action": 1,
+                    "PolicyID": "2",
+                    "ServiceID": ""
+                },
+                "Port": "443",
+                "Protocol": "TCP"
+            },
+            {
+                "Address": "0.0.0.0/0",
+                "Policy": {
+                    "Action": 1,
+                    "PolicyID": "3",
+                    "ServiceID": ""
+                },
+                "Port": "",
+                "Protocol": "icmp"
+            },
+            {
+                "Address": "0.0.0.0/0",
+                "Policy": {
+                    "Action": 1,
+                    "PolicyID": "4",
+                    "ServiceID": ""
+                },
+                "Port": "53",
+                "Protocol": "udp"
+            }
+        ],
+        "NetworkACLs": [
+            {
+                "Address": "0.0.0.0/0",
+                "Policy": {
+                    "Action": 1,
+                    "PolicyID": "7",
+                    "ServiceID": ""
+                },
+                "Port": "",
+                "Protocol": "icmp"
+            }
+        ],
+        "TagSelectors": [
+            {
+                "Clause": [
+                    {
+                        "Key": "@usr:app",
+                        "Operator": "=",
+                        "Value": [
+                            "web"
+                        ]
+                    }
+                ],
+                "Policy": {
+                    "Action": 1,
+                    "PolicyID": "8",
+                    "ServiceID": ""
+                }
+            },
+            {
+                "Clause": [
+                    {
+                        "Key": "@usr:env",
+                        "Operator": "=",
+                        "Value": [
+                            "dev"
+                        ]
+                    }
+                ],
+                "Policy": {
+                    "Action": 1,
+                    "PolicyID": "8",
+                    "ServiceID": ""
+                }
+            }
+        ]
+    },
+    "DB": {
+        "ApplicationACLs": [
+            {
+                "Address": "0.0.0.0/0",
+                "Policy": {
+                    "Action": 1,
+                    "PolicyID": "4",
+                    "ServiceID": ""
+                },
+                "Port": "53",
+                "Protocol": "udp"
+            }
+        ],
+        "NetworkACLs": [
+        ],
+        "TagSelectors": [
+            {
+                "Clause": [
+                    {
+                        "Key": "@usr:app",
+                        "Operator": "=",
+                        "Value": [
+                            "db"
+                        ]
+                    }
+                ],
+                "Policy": {
+                    "Action": 1,
+                    "PolicyID": "8",
+                    "ServiceID": ""
+                }
+            }
+        ]
+    }
+}

--- a/policyexample/policy.go
+++ b/policyexample/policy.go
@@ -100,7 +100,7 @@ func (p *CustomPolicyResolver) ResolvePolicy(context string, runtimeInfo policy.
 
 	policyIndex, err := GetPolicyIndex(runtimeInfo)
 	if err != nil {
-		zap.L().Warn("Cannot find requested policy index - Associating default policy - drop-all")
+		zap.L().Warn("Cannot find requested policy index - Associating default policy")
 		policyIndex = "default"
 	}
 

--- a/policyexample/policy.go
+++ b/policyexample/policy.go
@@ -54,6 +54,8 @@ func LoadPolicies(file string) map[string]*CachedPolicy {
 
 	configFile.Close() //nolint
 
+	zap.L().Info("Using policy from file", zap.String("Policy File", file))
+
 	return config
 }
 
@@ -67,6 +69,7 @@ func GetPolicyIndex(runtimeInfo policy.RuntimeReader) (string, error) {
 
 		parts := strings.SplitN(tag, "=", 2)
 		if strings.HasPrefix(parts[0], "@usr:PolicyIndex") {
+			zap.L().Info("Using policy from file", zap.String("Policy ID", parts[1]))
 			return parts[1], nil
 		}
 	}
@@ -97,7 +100,7 @@ func (p *CustomPolicyResolver) ResolvePolicy(context string, runtimeInfo policy.
 
 	policyIndex, err := GetPolicyIndex(runtimeInfo)
 	if err != nil {
-		zap.L().Error("Cannot find requested policy index - Associating default policy - drop-all")
+		zap.L().Warn("Cannot find requested policy index - Associating default policy - drop-all")
 		policyIndex = "default"
 	}
 

--- a/triremecli/cli.go
+++ b/triremecli/cli.go
@@ -116,6 +116,8 @@ func processDaemonArgs(arguments map[string]interface{}, processor enforcer.Pack
 		}
 	}
 
+	policyFile := arguments["--policy"].(string)
+
 	targetNetworks := []string{}
 	if len(arguments["--target-networks"].([]string)) > 0 {
 		zap.L().Info("Target Networks", zap.Strings("networks", arguments["--target-networks"].([]string)))
@@ -135,10 +137,10 @@ func processDaemonArgs(arguments map[string]interface{}, processor enforcer.Pack
 				zap.String("ca", caCertFile),
 				zap.String("ca", caCertKeyFile),
 			)
-			t, m = constructors.TriremeWithCompactPKI(keyFile, certFile, caCertFile, caCertKeyFile, targetNetworks, &customExtractor, remote, KillContainerOnError)
+			t, m = constructors.TriremeWithCompactPKI(keyFile, certFile, caCertFile, caCertKeyFile, targetNetworks, &customExtractor, remote, KillContainerOnError, policyFile)
 		} else {
 			zap.L().Info("Setting up trireme with PSK")
-			t, m = constructors.TriremeWithPSK(targetNetworks, &customExtractor, remote, KillContainerOnError)
+			t, m = constructors.TriremeWithPSK(targetNetworks, &customExtractor, remote, KillContainerOnError, policyFile)
 		}
 	} else { // Hybrid mode
 		if arguments["--usePKI"].(bool) {
@@ -152,9 +154,9 @@ func processDaemonArgs(arguments map[string]interface{}, processor enforcer.Pack
 				zap.String("ca", caCertFile),
 				zap.String("ca", caCertKeyFile),
 			)
-			t, m, rm = constructors.HybridTriremeWithCompactPKI(keyFile, certFile, caCertFile, caCertKeyFile, targetNetworks, &customExtractor, true, KillContainerOnError)
+			t, m, rm = constructors.HybridTriremeWithCompactPKI(keyFile, certFile, caCertFile, caCertKeyFile, targetNetworks, &customExtractor, true, KillContainerOnError, policyFile)
 		} else {
-			t, m, rm = constructors.HybridTriremeWithPSK(targetNetworks, &customExtractor, KillContainerOnError)
+			t, m, rm = constructors.HybridTriremeWithPSK(targetNetworks, &customExtractor, KillContainerOnError, policyFile)
 			if rm == nil {
 				zap.L().Fatal("Failed to create remote monitor for hybrid")
 			}
@@ -164,7 +166,7 @@ func processDaemonArgs(arguments map[string]interface{}, processor enforcer.Pack
 
 	if arguments["--cni"].(bool) {
 		zap.L().Info("Setting up CNI trireme with PSK")
-		t, m = constructors.TriremeCNIWithPSK(targetNetworks, false, KillContainerOnError)
+		t, m = constructors.TriremeCNIWithPSK(targetNetworks, false, KillContainerOnError, policyFile)
 	}
 
 	if t == nil {


### PR DESCRIPTION
Allow trireme-example to load policy through a JSON file. This illustrates better how it can be used.